### PR TITLE
add apiVersion to sanity client config

### DIFF
--- a/src/components/autocompleteTagsComponent.js
+++ b/src/components/autocompleteTagsComponent.js
@@ -11,7 +11,9 @@ import Select from "react-select"
 import Fieldset from "part:@sanity/components/fieldsets/default"
 import PatchEvent, { set, unset } from "part:@sanity/form-builder/patch-event"
 import { withDocument } from "part:@sanity/form-builder"
-import client from "part:@sanity/base/client"
+import sanityClient from "part:@sanity/base/client"
+
+const client = sanityClient.withConfig({apiVersion: '2021-03-25'})
 
 const createPatchFrom = (value) =>
   PatchEvent.from(value === "" ? unset() : set(value))


### PR DESCRIPTION
Adds `withConfig` to client to remove clientless version deprecation warning. 