### PR TITLE
Optimize fetch tags query

### DIFF
--- a/src/components/autocompleteTagsComponent.js
+++ b/src/components/autocompleteTagsComponent.js
@@ -49,30 +49,16 @@ const autocompleteTagsComponent = forwardRef((props, ref) => {
     setIsLoading(true)
 
     // Query for the document type and return the whole thing
-    const query = `*[_type == '${document}'] { ... }`
+    const query = `*[_type == $document && count(tags) > 0].tags[]`
 
     const fetchTags = async () => {
-      const allTags = [[...preloadedTags]]
-      client.fetch(query).then(items => {
-        items.forEach(item => {
-          if (item.tags && item.tags.length > 0 && item.tags !== null) {
-            // this could be a item?.tags?.length or something?
-            allTags.push(item.tags)
-          }
-          return
-        })
+      const allTags = await client.fetch(query, { document })
+      console.log(allTags)
 
-        // At this point, we have an array of arrays. Let's flatten this sucker!
-        // @ts-ignore
-        const flatTags = allTags.flat().filter((tag) => {
-          if (typeof tag !== "string") {
-            return tag
-          }
-        })
         // Now, let's create a new array that only includes unique tags
         const uniqueTags = []
         const map = new Map()
-        for (const tag of flatTags) {
+        for (const tag of allTags) {
           if (!map.has(tag.value)) {
             map.set(tag.value, true)
             uniqueTags.push({
@@ -82,8 +68,7 @@ const autocompleteTagsComponent = forwardRef((props, ref) => {
           }
         }
 
-        setUniqueTags(uniqueTags)
-      })
+      setUniqueTags(uniqueTags)
     }
 
     // Ok, now let's populate the dropdown with tags already assigned.

--- a/src/components/autocompleteTagsComponent.js
+++ b/src/components/autocompleteTagsComponent.js
@@ -53,7 +53,6 @@ const autocompleteTagsComponent = forwardRef((props, ref) => {
 
     const fetchTags = async () => {
       const allTags = await client.fetch(query, { document })
-      console.log(allTags)
 
         // Now, let's create a new array that only includes unique tags
         const uniqueTags = []

--- a/src/components/autocompleteTagsComponent.js
+++ b/src/components/autocompleteTagsComponent.js
@@ -11,7 +11,9 @@ import Select from "react-select"
 import Fieldset from "part:@sanity/components/fieldsets/default"
 import PatchEvent, { set, unset } from "part:@sanity/form-builder/patch-event"
 import { withDocument } from "part:@sanity/form-builder"
-import client from "part:@sanity/base/client"
+import sanityClient from "part:@sanity/base/client"
+
+const client = sanityClient.withConfig({apiVersion: '2021-03-25'})
 
 const createPatchFrom = (value) =>
   PatchEvent.from(value === "" ? unset() : set(value))


### PR DESCRIPTION
Since my last commit updates the client to use the latest version of the API, we can leverage some of GROQ's features to make the initial query return a flat array of tags. 